### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ An animation change foreground color lyric color for karaoke apps.
 ## Usage
 - Import folder VTXKaraokeView classes into your project and import header:
 ```
-#import "VTXKaraokeLyricView.h"
+# import "VTXKaraokeLyricView.h"
 ```
 It is a subclass from UILabel, so you can use all UILabel properties such as: Font, textColor, ....
  


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
